### PR TITLE
Made base for hitboxes 

### DIFF
--- a/hitbox.gd
+++ b/hitbox.gd
@@ -1,0 +1,11 @@
+extends Area3D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass

--- a/player_movement.gd
+++ b/player_movement.gd
@@ -5,26 +5,30 @@ const SPEED = 5.0
 const JUMP_VELOCITY = 4.5
 const HORIZONTAL_JUMP_VELOCITY = 3
 
+var value_change = 1
+
 
 func _physics_process(delta: float) -> void:
-	# Add the gravity.
 	if not is_on_floor():
 		velocity += get_gravity() * delta
 
-	# Get the input direction and handle the movement/deceleration.
-	# As good practice, you should replace UI actions with custom gameplay actions.
 	var input_dir := Input.get_vector("p1left", "p1right", "ui_up", "ui_down")
 	var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
-	if direction and is_on_floor():
-		velocity.x = direction.x * SPEED
-		#velocity.z = direction.z * SPEED
-	if !direction and is_on_floor():
-		velocity.x = move_toward(velocity.x, 0, SPEED)
-		#velocity.z = move_toward(velocity.z, 0, SPEED)
+	
+	if direction and is_on_floor(): # change mv
+		velocity.x = direction.x * SPEED * value_change
+	if !direction and is_on_floor(): #mv
+		velocity.x = move_toward(velocity.x, 0, SPEED * value_change)
 		
-		# Handle jump.
 	if Input.is_action_just_pressed("p1jump") and is_on_floor():
-		velocity.y = JUMP_VELOCITY
-		velocity.x = direction.x * HORIZONTAL_JUMP_VELOCITY
+		velocity.y = JUMP_VELOCITY * value_change
+		velocity.x = direction.x * HORIZONTAL_JUMP_VELOCITY * value_change
 
 	move_and_slide()
+
+
+func _on_test_attack_is_attacking(is_attacking: Variant) -> void:
+	if is_attacking == true:
+		value_change = 0
+	else:
+		value_change = 1

--- a/player_movement_test_scene.tscn
+++ b/player_movement_test_scene.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=11 format=3 uid="uid://b7oqgbyre1xbw"]
+[gd_scene load_steps=13 format=3 uid="uid://b7oqgbyre1xbw"]
 
 [ext_resource type="Script" path="res://camera_3d.gd" id="1_2pivu"]
 [ext_resource type="Script" path="res://player_movement.gd" id="1_yo7gw"]
 [ext_resource type="Script" path="res://player_2_movement.gd" id="2_yqd0b"]
+[ext_resource type="Script" path="res://test_attack.gd" id="3_usowe"]
+[ext_resource type="PackedScene" uid="uid://by3k2enn78p6a" path="res://test_hitbox_scene.tscn" id="4_k76gx"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_65324"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -66,6 +68,12 @@ mesh = SubResource("CapsuleMesh_qitd7")
 transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0, 0)
 shape = SubResource("ConvexPolygonShape3D_58lea")
 
+[node name="TestAttack" type="Node3D" parent="player1"]
+script = ExtResource("3_usowe")
+hitbox_scene = ExtResource("4_k76gx")
+
+[node name="AttackTimer" type="Timer" parent="player1/TestAttack"]
+
 [node name="player2" type="CharacterBody3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.05634, 0.463683, -0.123802)
 axis_lock_linear_z = true
@@ -78,3 +86,5 @@ mesh = SubResource("CapsuleMesh_qitd7")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="player2"]
 transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0, 0)
 shape = SubResource("ConvexPolygonShape3D_58lea")
+
+[connection signal="is_attacking" from="player1/TestAttack" to="player1" method="_on_test_attack_is_attacking"]

--- a/project.godot
+++ b/project.godot
@@ -142,3 +142,8 @@ p2right={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+"p1 test attack"={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+]
+}

--- a/test_attack.gd
+++ b/test_attack.gd
@@ -1,0 +1,62 @@
+extends Node3D
+
+@export var hitbox_scene : PackedScene
+@export var start_up_duration : float = 0.5
+@export var hitbox_duration : float = 0.5  
+@export var endlag_duration : float = 0.5
+@export var hit_stun_duration : float = 0.5
+@export var hit_stop_duration : float = 0.5
+@export var block_stun_duration : float = 0.5
+@export var damage : float = 1.0
+@export var hitbox_offset : Vector3 = Vector3(1, 0, 0)
+@export var hitbox_rotation : Vector3 = Vector3(0, 90, 0)
+
+signal is_attacking(is_attacking)
+
+@onready var attack_timer : Timer = $AttackTimer
+var hitbox : Area3D = null
+
+enum AttackPhase {
+	AVAILABLE,
+	STARTUP,
+	ACTIVE,
+	ENDLAG
+}
+var current_phase : AttackPhase = AttackPhase.AVAILABLE
+
+func _ready():
+	attack_timer.timeout.connect(_on_attack_timeout)
+	attack_timer.autostart = false
+	
+func _process(delta):
+	if Input.is_action_just_pressed("p1 test attack") and current_phase == AttackPhase.AVAILABLE:
+		emit_signal("is_attacking", true)
+		set_up_hitbox()
+
+func set_up_hitbox():
+	hitbox = hitbox_scene.instantiate()
+
+	hitbox.transform.origin = hitbox_offset
+	hitbox.rotation_degrees = hitbox_rotation
+	
+	current_phase = AttackPhase.STARTUP
+	attack_timer.start(start_up_duration)
+
+func _on_attack_timeout():
+	match current_phase:
+		AttackPhase.STARTUP:
+			current_phase = AttackPhase.ACTIVE
+			get_parent().add_child(hitbox)
+			attack_timer.start(hitbox_duration)
+		
+		AttackPhase.ACTIVE:
+			current_phase = AttackPhase.ENDLAG
+			attack_timer.start(endlag_duration)
+
+		AttackPhase.ENDLAG:
+			if hitbox:
+				hitbox.queue_free()
+				hitbox = null
+			emit_signal("is_attacking", false)
+			current_phase = AttackPhase.AVAILABLE
+			

--- a/test_hitbox_scene.tscn
+++ b/test_hitbox_scene.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3 uid="uid://by3k2enn78p6a"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_bgrns"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_m40an"]
+
+[node name="Hitbox" type="Area3D"]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("BoxShape3D_bgrns")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="CollisionShape3D"]
+mesh = SubResource("BoxMesh_m40an")


### PR DESCRIPTION
Press space bar to activate hitbox on player 1.

Isn't safe to merge because I an unable to pull the latest updates for some reason. Im trying to solve that but for this I had to work on an earlier version of the game. I made a new scene and added a not to player 1 for a new hitbox script. 

Note
- Doesn't interact with other player yet so there are variables like hit stun and stop that aren't being used yet. 
- The is a glitch where if you use the attach in the air and you land while the attack is still active you slide on the ground until the attack is done. The attack should probably cancel as soon as the player touches the ground in the finished product. 
